### PR TITLE
[Example] - Add Llama 3.2 Page

### DIFF
--- a/app/category/generate-text/llama-3.2/page.tsx
+++ b/app/category/generate-text/llama-3.2/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Llama32Page: React.FC = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <h1 className="text-4xl md:text-6xl lg:text-8xl font-bold text-gray-800">
+        Llama 3.2
+      </h1>
+    </div>
+  );
+};
+
+export default Llama32Page;

--- a/lib/categories.tsx
+++ b/lib/categories.tsx
@@ -7,7 +7,7 @@ import SentimentAnalysisIcon from './icons/SentimentAnalysisIcon';
 import EmbeddingIcon from './icons/EmbeddingIcon';
 import ClassificationIcon from './icons/ClassificationIcon';
 import TextGenerationIcon from './icons/TextGenerationIcon';
-
+import Llama32Page from '@/app/category/generate-text/llama-3.2/page';
 export const categories: Category[] = [
   {
     title: "Generate Text",
@@ -16,7 +16,15 @@ export const categories: Category[] = [
     description: "Llama. Qwen. Enough said.",
     status: "Available",
     colorName: "blue",
-    graphic: TextGenerationIcon
+    graphic: TextGenerationIcon,
+    demos: [
+      {
+        title: "Llama 3.2",
+        slug: "llama-3.2",
+        component: Llama32Page,
+        description: "Llama 3.2 in the browser. WebGPU FTW."
+      }
+    ]
   },
   {
     title: "Transcribe",


### PR DESCRIPTION
# Example of Adding Page to Playground

### Steps

#### 1. Add Route
Add the page where the demo will go under the category it belongs in. You can create hooks, components, and types as needed.

**Example**
```
app
└── category
    └── [slug]
        └── generate-text
            └── llama-3.2
                └── page.tsx
```
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/1903e56a-5ecd-4587-a382-579cfcc72763">

#### 2. Add demo to `categories.tsx`, this will allow it to show up on Categories Page
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/1f1680af-9d9b-45b2-84a5-658b750fe020">

```ts
  {
    title: "Generate Text",
    slug: "generate-text",
    icon: Type,
    description: "Llama. Qwen. Enough said.",
    status: "Available",
    colorName: "blue",
    graphic: TextGenerationIcon,
    demos: [
      {
        title: "Llama 3.2",
        slug: "llama-3.2",
        component: Llama32Page,
        description: "Llama 3.2 in the browser. WebGPU FTW."
      }
    ]
  }
```
